### PR TITLE
Upgrade go and ids with apostrophe

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   postgres:
-    image: postgres:10.3-alpine
+    image: postgres:11
     container_name: scramjet_postgres
     volumes:
       - postgres:/var/lib/postgresql/data

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OIT-ADS-Web/scramjet
 
-go 1.14
+go 1.16
 
 require (
 	github.com/gorilla/mux v1.7.4

--- a/psql_staging_test.go
+++ b/psql_staging_test.go
@@ -10,12 +10,13 @@ import (
 
 func setup() {
 	// TODO: probably better way to do this
+	// NOTE: changed to docker setup user (couldn't get 'docker' user recognized)
 	database := sj.DatabaseInfo{
 		Server:         "localhost",
-		Database:       "docker",
-		Password:       "docker",
+		Database:       "json_data",
+		Password:       "json_data",
 		Port:           5433,
-		User:           "docker",
+		User:           "json_data",
 		MaxConnections: 1,
 		AcquireTimeout: 30,
 	}


### PR DESCRIPTION
I was NOT using parameterized sql for '...where (id, type) in (<id>, <type>)...' - because this is not a common enough use case to be handled well by the library (as far as I can tell)

I did find one approach that seems to work though, creating '($1, $2), ($3, $4) etc...' parameters for those and substituting in like normal.  That fixes the case of an id that has an apostrophe (or any other characters)

As long as I was here I thought I'd upgrade postgres to version we use, and up the go version too
